### PR TITLE
🔧 Add naming conventions

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,15 @@ module.exports = {
         "modifiers": ["unused"],
         "leadingUnderscore": "require",
         "format": null
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"]
+      },
+      {
+        "selector": "variable",
+        "format": ["UPPER_CASE", "strictCamelCase"],
+        "modifiers": ["const", "global"]
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paralenz/eslint-config-typescript-react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Paralenz eslint configuration for typescript and React",
   "main": "index.js",
   "scripts": {

--- a/tests/@typescript-eslint/naming-convention/const.ts
+++ b/tests/@typescript-eslint/naming-convention/const.ts
@@ -1,0 +1,3 @@
+const FOO_BAR = 'Global constants should be allowed'
+
+exports = FOO_BAR

--- a/tests/@typescript-eslint/naming-convention/enum-camel-case.error.ts
+++ b/tests/@typescript-eslint/naming-convention/enum-camel-case.error.ts
@@ -1,0 +1,3 @@
+enum Foo {
+  camelCase = 1
+}

--- a/tests/@typescript-eslint/naming-convention/enum-pascal-case.ts
+++ b/tests/@typescript-eslint/naming-convention/enum-pascal-case.ts
@@ -1,0 +1,3 @@
+enum Foo {
+  PascalCase = 1
+}

--- a/tests/@typescript-eslint/naming-convention/enum-upper-case.error.ts
+++ b/tests/@typescript-eslint/naming-convention/enum-upper-case.error.ts
@@ -1,0 +1,3 @@
+enum Foo {
+  UPPER_CASE = 1
+}

--- a/tests/@typescript-eslint/naming-convention/local-const.error.ts
+++ b/tests/@typescript-eslint/naming-convention/local-const.error.ts
@@ -1,0 +1,4 @@
+export function foo() {
+  const LOCAL_CONST = 'local consts should not be allowed'
+  return LOCAL_CONST
+}

--- a/tests/rules.spec.js
+++ b/tests/rules.spec.js
@@ -44,7 +44,7 @@ const describeRule = rule => {
         it(test, async () => {
           const [r] = await eslint.lintFiles([join(dir, test)])
 
-          const messages = r.messages.filter(msg => msg.ruleId.startsWith(rule))
+          const messages = r.messages.filter(msg => msg.ruleId && msg.ruleId.startsWith(rule))
           const warnings = messages.filter(msg => msg.severity === 1)
           const errors = messages.filter(msg => msg.severity === 2)
 


### PR DESCRIPTION
enum members should be PascalCase (folloing typescript guidelines)

```typescript
enum Foo {
  ThisShouldBePascalCase = "..."
}
``` 

global consts should be UPPER_CASE. For now keep strictCamelCase for this, but I think we might should remove that?